### PR TITLE
resources :examplesに関する文法エラー修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root to: "examples#index"
   resources :tags
   resources :iines
-  resources :examples, only: [:index, :show, :new, :create, :destroy, :edit, :update] do
+  resources :examples, only: [:index, :show, :new, :create, :destroy, :edit, :update]
   resources :users, only: [:show, :edit, :update]
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".


### PR DESCRIPTION
resources :examplesに関する文法エラー修正
→ resources :examples, only: [:index, :show, :new, :create, :destroy, :edit, :update] 
※最後の do を消した